### PR TITLE
Support JSON::XS 4

### DIFF
--- a/lib/JSON/Any.pm
+++ b/lib/JSON/Any.pm
@@ -207,9 +207,17 @@ BEGIN {
     );
 
     # JSON::PP has the same API as JSON.pm v2
-    $conf{json_pp} = { %{ $conf{json_2} } };
-    $conf{json_pp}{get_true}  = sub { return JSON::PP::true(); };
-    $conf{json_pp}{get_false} = sub { return JSON::PP::false(); };
+    $conf{json_pp_2} = { %{ $conf{json_2} } };
+    $conf{json_pp_2}{get_true}  = sub { return JSON::PP::true(); };
+    $conf{json_pp_2}{get_false} = sub { return JSON::PP::false(); };
+
+    # JSON::PP 3.99 enables allow_nonref by default.
+    $conf{json_pp_3} = { %{ $conf{json_pp_2} } };
+    $conf{json_pp_3}{create_object} = sub {
+        $conf{json_pp_2}{create_object}->($_[0], {allow_nonref => 0, %{$_[1]}});
+    };
+
+    $conf{json_pp_4} = { %{ $conf{json_pp_3} } };
 
     # Cpanel::JSON::XS is a fork of JSON::XS (currently)
     $conf{cpanel_json_xs} = { %{ $conf{json_xs_2} } };
@@ -224,12 +232,15 @@ BEGIN {
     # JSON::XS 4 is almost the same as JSON::XS 3. It only enables
     # allow_nonref by default.
     $conf{json_xs_4} = { %{ $conf{json_xs_3} } };
+    $conf{json_xs_4}{create_object} = sub {
+        $conf{json_xs_3}{create_object}->($_[0], {allow_nonref => 0, %{$_[1]}});
+    };
 }
 
 sub _make_key {
     my $handler = shift;
     ( my $key = lc($handler) ) =~ s/::/_/g;
-    if ( 'json_xs' eq $key || 'json' eq $key ) {
+    if ( 'json_xs' eq $key || 'json_pp' eq $key || 'json' eq $key ) {
         no strict 'refs';
         $key .= "_" . ( split /\./, ${"$handler\::VERSION"} )[0];
     }

--- a/lib/JSON/Any.pm
+++ b/lib/JSON/Any.pm
@@ -220,6 +220,10 @@ BEGIN {
     $conf{json_xs_3} = { %{ $conf{json_xs_2} } };
     $conf{json_xs_3}{get_true}  = sub { return Types::Serialiser::true(); };
     $conf{json_xs_3}{get_false} = sub { return Types::Serialiser::false(); };
+
+    # JSON::XS 4 is almost the same as JSON::XS 3. It only enables
+    # allow_nonref by default.
+    $conf{json_xs_4} = { %{ $conf{json_xs_3} } };
 }
 
 sub _make_key {

--- a/t/15-allow_nonref.t
+++ b/t/15-allow_nonref.t
@@ -1,0 +1,48 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Fatal;
+use JSON::Any;
+
+my @backends = qw(CPANEL XS PP JSON DWIW);
+
+plan tests => @backends * 2 * 3;
+
+test ($_) for @backends;
+
+sub test {
+    my ($backend) = @_;
+
+    SKIP: {
+        my $j = eval {
+            JSON::Any->import($backend);
+            JSON::Any->new;
+        };
+
+        note("$backend: " . $@), skip("Backend $backend failed to load", 2 * 3) if $@;
+
+        $j and $j->handler or next;
+
+        note "handler is " . ( ref( $j->handler ) || $j->handlerType );
+
+        for my $json ( 'null', '42', '"hello"' ) {
+            my $data;
+            isnt(
+                exception { $data = $j->jsonToObj($json) },
+                undef,
+                "decoding '$json' is not supported",
+            );
+        }
+
+        for my $object ( undef, 42, 'hello' ) {
+            my $json;
+            my $printable_object = $object // 'undef';
+            isnt(
+                exception { $json = $j->objToJson($object) },
+                undef,
+                "encoding '$printable_object' is not supported",
+            );
+        }
+    };
+}


### PR DESCRIPTION
JSON::XS 4 has the same API as version 3. It only enables allow_nonref
by default.

CPAN RT#127753