### PR TITLE
stop trying to call JSON->import for JSON::PP

### DIFF
--- a/lib/JSON/Any.pm
+++ b/lib/JSON/Any.pm
@@ -217,6 +217,10 @@ BEGIN {
       };
     }
 
+    # JSON.pm v3 and v4 are the same as v2
+    $conf{json_3} = { %{ $conf{json_2} } };
+    $conf{json_4} = { %{ $conf{json_3} } };
+
     # Cpanel::JSON::XS is a fork of JSON::XS (currently)
     $conf{cpanel_json_xs} = { %{ $conf{json_xs_2} } };
     $conf{cpanel_json_xs}{get_true}  = sub { return Cpanel::JSON::XS::true(); };
@@ -226,6 +230,9 @@ BEGIN {
     $conf{json_xs_3} = { %{ $conf{json_xs_2} } };
     $conf{json_xs_3}{get_true}  = sub { return Types::Serialiser::true(); };
     $conf{json_xs_3}{get_false} = sub { return Types::Serialiser::false(); };
+
+    # JSON::XS v4 is the same as v3
+    $conf{json_xs_4} = { %{ $conf{json_xs_3} } };
 }
 
 sub _make_key {

--- a/lib/JSON/Any.pm
+++ b/lib/JSON/Any.pm
@@ -56,13 +56,12 @@ BEGIN {
                 $self->[HANDLER] = $obj;
             },
         },
-        json_2 => {
+        json_pp => {
             encoder       => 'encode_json',
             decoder       => 'decode_json',
-            get_true      => sub { return JSON::true(); },
-            get_false     => sub { return JSON::false(); },
+            get_true      => sub { return JSON::PP::true(); },
+            get_false     => sub { return JSON::PP::false(); },
             create_object => sub {
-                JSON->import( '-support_by_pp', '-no_export' );
                 my ( $self, $conf ) = @_;
                 my @params = qw(
                   ascii
@@ -206,10 +205,17 @@ BEGIN {
         },
     );
 
-    # JSON::PP has the same API as JSON.pm v2
-    $conf{json_pp} = { %{ $conf{json_2} } };
-    $conf{json_pp}{get_true}  = sub { return JSON::PP::true(); };
-    $conf{json_pp}{get_false} = sub { return JSON::PP::false(); };
+    # JSON.pm v2 has the same API as JSON::PP
+    $conf{json_2} = { %{ $conf{json_pp} } };
+    $conf{json_2}{get_true}  = sub { return JSON::true(); };
+    $conf{json_2}{get_false} = sub { return JSON::false(); };
+    {
+      my $create = $conf{json_2}{create_object};
+      $conf{json_2}{create_object} = sub {
+        JSON->import( '-support_by_pp', '-no_export' );
+        goto &$create;
+      };
+    }
 
     # Cpanel::JSON::XS is a fork of JSON::XS (currently)
     $conf{cpanel_json_xs} = { %{ $conf{json_xs_2} } };


### PR DESCRIPTION
The configuration for JSON::PP was copying the configuration for JSON v2. This would mostly work, but included a call to JSON->import to configure the module. Up until now, that import call would just be ignored if JSON.pm was not loaded, but future versions of perl will
start warning or dying for that.

Instead, make the JSON.pm v2 configuration a copy of JSON::PP, but wrapping the create_object sub to add the import call.